### PR TITLE
Added install of libffi-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ubuntu users can install the needed packages using:
 sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
 sudo add-apt-repository -y ppa:pmiller-opensource/ppa
 sudo apt-get update
-sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord
+sudo apt-get install cmake ninja-build gcc-arm-none-eabi srecord libffi-dev
 pip3 install yotta
 ```
 


### PR DESCRIPTION
I am using ubuntu to install yotta and I had to also install libffi-dev for yotta to install correctly.
